### PR TITLE
Fixing scoped css component

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ If you want your Box to support styled-system props like [space](https://styled-
 + import withStyledSystem from 'styled-jsx-system'
 
 - const Box = ({ children }) => {
-+ const Box = ({ className, children }) => {
++ const Box = ({ className, styles, children }) => {
   return (
 -   <div>
 +   <div className={className}>
@@ -54,6 +54,7 @@ If you want your Box to support styled-system props like [space](https://styled-
           padding: 8px;
         }
       `}</style>
++     {styles}
     </div>
   )
 }
@@ -105,13 +106,14 @@ import { system } from 'styled-system'
 const customProp = system({
   lineClamp: {
     property: 'WebkitLineClamp',
-    transform: (lines) => String(lines)
+    transform: lines => String(lines)
   }
 })
 
 export default withStyledSystem(Box, [customProp])
 // <Box /> now supports the lineClamp prop (i.e. <Box lineClamp={3} />)
 ```
+
 <br />
 
 ### Themeing

--- a/examples/components/box.js
+++ b/examples/components/box.js
@@ -1,8 +1,13 @@
 import styledJsxSystem from 'styled-jsx-system'
 import { color, typography, space } from 'styled-system'
 
-const Box = ({ children, className }) => {
-  return <div className={className}>{children}</div>
+const Box = ({ children, className, styles }) => {
+  return (
+    <div className={className}>
+      {children}
+      {styles}
+    </div>
+  )
 }
 
 export default styledJsxSystem(

--- a/examples/pages/index.js
+++ b/examples/pages/index.js
@@ -7,8 +7,11 @@ const scope = { Box, ThemeProvider, styledSystem, withStyledSystem }
 
 const code = `
 () => {
-  const BoxComponent = ({ className, children }) => (
-    <div className={className}>{children}</div>
+  const BoxComponent = ({ className, styles, children }) => (
+    <div className={className}>
+      {children}
+      {styles}
+    </div>
   )
 
   const Box = withStyledSystem(
@@ -87,9 +90,9 @@ const Index = () => {
         <LiveError />
       </LiveProvider>
 
-      {/* <Box color="#fff" bg={['#FF0080', '#7928CA', '#0070F3']}>
+      <Box color="blue" bg={['#FF0080', '#7928CA', '#0070F3']}>
         Box component here
-      </Box> */}
+      </Box>
 
       <style jsx>{`
         main {
@@ -106,7 +109,8 @@ const Index = () => {
           width: 100%;
         }
 
-        .editor :global(textarea), .editor :global(pre) {
+        .editor :global(textarea),
+        .editor :global(pre) {
           line-height: 1.7 !important;
         }
 

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -69,15 +69,9 @@ const HOC = (Component, opts) => {
       <Component
         {...props}
         className={cn(className, [...styles.map(s => s.className)])}
+        styles={styles.map(s => s.styles)}
       >
         {children}
-        {styles.map((s, i) => {
-          return (
-            <React.Fragment key={`styled-system-${i}`}>
-              {s.styles}
-            </React.Fragment>
-          )
-        })}
       </Component>
     )
   }


### PR DESCRIPTION
Hi @pacocoursey :) ty for the lib, it's really useful!

## What's happening
Using the lib I noticed when we have a `<style jsx>` inside a component with some css and try to modify via `styled-system` the order of import the css component (`<style id="...">` ) override the changes.

Example:
```
const Box = ({ children, className }) => {
  return (
    <div className={className}>
      {children}

     <style jsx>{` 
       { color: red } 
     `}</style>
    </div>
  )
}
```

If we try to change the color with `<Box color="blue">` the red will continue to override the changes.

## What i did
- Removing map for styles in `HOC` and passing as a prop to `Component` and now we can add `{styles}` in the main component, so the styles passed as a prop will override the `<style jsx>` local like [css.resolve](https://github.com/zeit/styled-jsx#the-resolve-tag) did here.